### PR TITLE
Added command line options for working with h5 files

### DIFF
--- a/pycatchmod/__main__.py
+++ b/pycatchmod/__main__.py
@@ -28,22 +28,28 @@ def compare(ctx, filename, plot):
     from pycatchmod.io.excel import compare
     compare(filename, plot)
 
-def pandas_read(filename):
+def pandas_read(filename, key=None):
     import pandas  # TODO: move this somewhere else?
     if filename.endswith((".h5", ".hdf", ".hdf5")):
-        df = pandas.read_hdf(filename)
+        df = pandas.read_hdf(filename, key=key)
     elif filename.endswith((".csv")):
         df = pandas.read_csv(filename, parse_dates=True, dayfirst=True)
         df.set_index(df.columns[0], inplace=True)
     return df
 
 @cli.command()
-@click.option("--parameters", type=click.Path(exists=True), required=True)
-@click.option("--rainfall", type=click.Path(exists=True), required=True)
-@click.option("--pet", type=click.Path(exists=True), required=True)
-@click.option("--output", type=click.Path(exists=None), required=True)
+@click.option("--parameters", type=click.Path(exists=True), required=True, help="Path to parameters JSON file")
+@click.option("--rainfall", type=click.Path(exists=True), required=True, help="Path to input rainfall data")
+@click.option("--rainfall-key", type=str, required=False, default=None, help="Key for input rainfall data (h5 files only)")
+@click.option("--pet", type=click.Path(exists=True), required=True, help="Path to input PET data")
+@click.option("--pet-key", type=str, required=False, default=None, help="Key for input PET data (h5 files only)")
+@click.option("--output", type=click.Path(exists=None), required=True, help="Path to output file (with .csv or .h5 extension)")
+@click.option("--output-key", type=str, default="flows", required=False, help="Key for output data (h5 files only)")
+@click.option("--output-mode", type=click.Choice(["w", "a", "r+"]), default="a", required=False, help="Mode for output file (h5 files only)")
+@click.option("--complib", type=click.Choice(["zlib", "bzip2", "lzo", "blosc", "none"]), required=False, default="zlib", help="Compression library (h5 files only)")
+@click.option("--complevel", type=click.IntRange(1, 9), required=False, default=9, help="Compression level (h5 files only)")
 @click.pass_context
-def run(ctx, parameters, rainfall, pet, output):
+def run(ctx, parameters, rainfall, pet, output, output_key, rainfall_key, pet_key, complib, complevel, output_mode):
     import pandas
     import numpy as np
     from pycatchmod.io.json import catchment_from_json
@@ -51,8 +57,8 @@ def run(ctx, parameters, rainfall, pet, output):
     from pycatchmod import run_catchmod
 
     # load rainfall and pet data
-    rainfall = pandas_read(rainfall)
-    pet = pandas_read(pet)
+    rainfall = pandas_read(rainfall, rainfall_key)
+    pet = pandas_read(pet, pet_key)
     num_scenarios = rainfall.shape[1]
 
     # load catchmod model
@@ -72,7 +78,7 @@ def run(ctx, parameters, rainfall, pet, output):
 
     # write output
     if output.endswith((".h5", ".hdf", ".hdf5")):
-        df.to_hdf(output, key="flows", compress="zlib")
+        df.to_hdf(output, key=output_key, mode=output_mode, complib=complib, complevel=complevel)
     elif output.endswith(".csv"):
         df.to_csv(output)
     else:


### PR DESCRIPTION
This PR adds several command line options related to working with h5 files. Users can now used h5 files with multiple tables as input data, specify the key for output data, and specify the compression library/level for the output. I've also added some help text to the run command.

It would perhaps be useful to add in a small utility to list the keys available in an h5 file, but that is left for another request.

Closes #30.